### PR TITLE
New api to support spark core

### DIFF
--- a/Convenus/Api/Api.cs
+++ b/Convenus/Api/Api.cs
@@ -150,8 +150,8 @@ namespace Convenus.Api
                 //event ending in 5 minutes
                 return (ushort)RoomStatus.Yellow;
 
-            //unknow
-            return (ushort)RoomStatus.Red;
+            //room is taken at the moment
+            return (ushort)RoomStatus.Green;
         }
 
         private static bool CheckAuth(string room, IDictionary<string,string> cookies)

--- a/Convenus/Api/Api.cs
+++ b/Convenus/Api/Api.cs
@@ -132,6 +132,11 @@ namespace Convenus.Api
             return events.Any(e => e.StartTime <= curTime && e.EndTime >= curTime);
         }
 
+        private ushort RoomStatus(List<CalendarEvent> events)
+        {
+            return 0;
+        }
+
         private static bool CheckAuth(string room, IDictionary<string,string> cookies)
         {
             if (!cookies.ContainsKey(AuthTokenKey)) return false;

--- a/Convenus/Api/Api.cs
+++ b/Convenus/Api/Api.cs
@@ -82,8 +82,8 @@ namespace Convenus.Api
                     return HttpStatusCode.Forbidden;
 
                 var events = ExchangeServiceHelper.GetRoomAvailability((string)_.room);
-                ushort result = this.GetRoomStatus(events, _.minutes);
-                return Response.AsText(result.ToString());
+                RoomStatus result = this.GetRoomStatus(events, _.minutes);
+                return Response.AsText(((int)result).ToString());
             };
 
             Post["/rooms/{room}/reservation"] = _ =>
@@ -144,25 +144,25 @@ namespace Convenus.Api
             return events.Any(e => e.StartTime <= curTime && e.EndTime >= curTime);
         }
 
-        private ushort GetRoomStatus(List<CalendarEvent> events, int minutes)
+        private RoomStatus GetRoomStatus(List<CalendarEvent> events, int minutes)
         {
             if (events == null || events.Count == 0)
                 //no events at all, so room is avaiable
-                return (ushort)RoomStatus.Blue;
+                return RoomStatus.Blue;
 
             var now = DateTime.Now;
             var evt = events.FirstOrDefault(e => e.StartTime <= now && e.EndTime >= now);
             if (evt == null)
                 //no matching events found, so room is available at this moment
-                return (ushort)RoomStatus.Blue;
+                return RoomStatus.Blue;
 
             var timeLeft = evt.EndTime.Subtract(now);
             if (timeLeft.Minutes <= minutes)
                 //event ending in x minutes
-                return (ushort)RoomStatus.Yellow;
+                return RoomStatus.Yellow;
 
             //room is taken at the moment
-            return (ushort)RoomStatus.Green;
+            return RoomStatus.Green;
         }
 
         private static bool CheckAuth(string room, IDictionary<string,string> cookies)

--- a/Convenus/Api/Api.cs
+++ b/Convenus/Api/Api.cs
@@ -132,9 +132,25 @@ namespace Convenus.Api
             return events.Any(e => e.StartTime <= curTime && e.EndTime >= curTime);
         }
 
-        private ushort RoomStatus(List<CalendarEvent> events)
+        private ushort GetRoomStatus(List<CalendarEvent> events)
         {
-            return 0;
+            if (events == null || events.Count == 0)
+                //no events at all, so room is avaiable
+                return (ushort)RoomStatus.Blue;
+
+            var now = DateTime.Now;
+            var evt = events.FirstOrDefault(e => e.StartTime <= now && e.EndTime >= now);
+            if (evt == null)
+                //no matching events found, so room is available at this moment
+                return (ushort)RoomStatus.Blue;
+
+            var timeLeft = evt.EndTime.Subtract(now);
+            if (timeLeft.Minutes <= 5)
+                //event ending in 5 minutes
+                return (ushort)RoomStatus.Yellow;
+
+            //unknow
+            return (ushort)RoomStatus.Red;
         }
 
         private static bool CheckAuth(string room, IDictionary<string,string> cookies)

--- a/Convenus/Api/Api.cs
+++ b/Convenus/Api/Api.cs
@@ -81,9 +81,16 @@ namespace Convenus.Api
                 if (Program.Options.RequireAuth.GetValueOrDefault(false) && !CheckAuth((string)_.room, Request.Cookies))
                     return HttpStatusCode.Forbidden;
 
-                var events = ExchangeServiceHelper.GetRoomAvailability((string)_.room);
-                RoomStatus result = this.GetRoomStatus(events, _.minutes);
-                return Response.AsText(((int)result).ToString());
+                try
+                {
+                    var events = ExchangeServiceHelper.GetRoomAvailability((string)_.room);
+                    RoomStatus result = this.GetRoomStatus(events, _.minutes);
+                    return Response.AsText(((int)result).ToString());
+                }
+                catch
+                {
+                    return Response.AsText(((int)RoomStatus.Unknown).ToString());
+                }
             };
 
             Post["/rooms/{room}/reservation"] = _ =>

--- a/Convenus/Api/Api.cs
+++ b/Convenus/Api/Api.cs
@@ -148,21 +148,21 @@ namespace Convenus.Api
         {
             if (events == null || events.Count == 0)
                 //no events at all, so room is avaiable
-                return RoomStatus.Blue;
+                return RoomStatus.Available;
 
             var now = DateTime.Now;
             var evt = events.FirstOrDefault(e => e.StartTime <= now && e.EndTime >= now);
             if (evt == null)
                 //no matching events found, so room is available at this moment
-                return RoomStatus.Blue;
+                return RoomStatus.Available;
 
             var timeLeft = evt.EndTime.Subtract(now);
             if (timeLeft.Minutes <= minutes)
                 //event ending in x minutes
-                return RoomStatus.Yellow;
+                return RoomStatus.EndOfMeeting;
 
             //room is taken at the moment
-            return RoomStatus.Green;
+            return RoomStatus.Taken;
         }
 
         private static bool CheckAuth(string room, IDictionary<string,string> cookies)

--- a/Convenus/Api/Api.cs
+++ b/Convenus/Api/Api.cs
@@ -70,7 +70,8 @@ namespace Convenus.Api
                         id=(string)_.room,
                         Events=events,
                         RoomList = roomList,
-                        AvailableRooms = availableRooms
+                        AvailableRooms = availableRooms,
+                        RoomStatus = this.GetRoomStatus(events)
                     });
                 };
 

--- a/Convenus/ExchangeServiceHelper.cs
+++ b/Convenus/ExchangeServiceHelper.cs
@@ -285,4 +285,24 @@ namespace Convenus
         public string Subject { get; set; }
 
     }
+
+    public enum RoomStatus
+    {
+        /// <summary>
+        /// Cannot connect to Convenus or network error
+        /// </summary>
+        Red,
+        /// <summary>
+        /// Room is taken
+        /// </summary>
+        Green,
+        /// <summary>
+        /// Room is avaiable
+        /// </summary>
+        Blue,
+        /// <summary>
+        /// Last x minutes until room is open
+        /// </summary>
+        Yellow
+    }
 }

--- a/Convenus/ExchangeServiceHelper.cs
+++ b/Convenus/ExchangeServiceHelper.cs
@@ -291,18 +291,18 @@ namespace Convenus
         /// <summary>
         /// Cannot connect to Convenus or network error
         /// </summary>
-        Red,
+        Unknown = 0,
         /// <summary>
         /// Room is taken
         /// </summary>
-        Green,
+        Taken = 1,
         /// <summary>
         /// Room is avaiable
         /// </summary>
-        Blue,
+        Available = 2,
         /// <summary>
         /// Last x minutes until room is open
         /// </summary>
-        Yellow
+        EndOfMeeting = 3
     }
 }


### PR DESCRIPTION
To prep for our awesome skunkwork project :stuck_out_tongue: we'll need some data from Convenus. We will be working with spark core to control the LED lighting, indicating the status of a meeting room. This PR includes the following changes:

* Added a new api call: /api/rooms/{room}/{minutes}, where {minutes} indicating the last x minutes until the room is available.
* The api will return an integer 0 - 3, indicating Unknown, Taken, Available and EndOfMeeting respectively. I thought about returning a standard json object as the rest of the apis, but decided against it as that will put the parsing on spark core.

@Briankaiser, @mpigsley would you guys please take a peek at this..