### PR TITLE
Spark Party Time

### DIFF
--- a/Convenus/Api/Api.cs
+++ b/Convenus/Api/Api.cs
@@ -74,7 +74,7 @@ namespace Convenus.Api
                 };
 
             // get room status for spark core, returns a number
-            Get["/rooms/{room}/{minutes}"] = _ =>
+            Get["/rooms/{room}/minutes/{minutes}"] = _ =>
             {
                 //if auth is enabled - check for the room
                 if (Program.Options.RequireAuth.GetValueOrDefault(false) && !CheckAuth((string)_.room, Request.Cookies))

--- a/Convenus/Api/Api.cs
+++ b/Convenus/Api/Api.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading.Tasks;
 using Nancy;
 using Nancy.Helpers;
 
@@ -154,19 +153,31 @@ namespace Convenus.Api
         private RoomStatus GetRoomStatus(List<CalendarEvent> events, int minutes)
         {
             if (events == null || events.Count == 0)
+            {
                 //no events at all, so room is avaiable
                 return RoomStatus.Available;
+            }
 
             var now = DateTime.Now;
             var evt = events.FirstOrDefault(e => e.StartTime <= now && e.EndTime >= now);
             if (evt == null)
+            {
                 //no matching events found, so room is available at this moment
-                return RoomStatus.Available;
+                return RoomStatus.Available; 
+            }
+
+            if (evt.Subject.ToLower().Contains("party"))
+            {
+                //event is a party, so make it one
+                return RoomStatus.Party;
+            }
 
             var timeLeft = evt.EndTime.Subtract(now);
             if (timeLeft.Minutes <= minutes)
+            {
                 //event ending in x minutes
                 return RoomStatus.EndOfMeeting;
+            }
 
             //room is taken at the moment
             return RoomStatus.Taken;

--- a/Convenus/ExchangeServiceHelper.cs
+++ b/Convenus/ExchangeServiceHelper.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using System.Net;
 using System.Runtime.Caching;
 using System.Security;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Exchange.WebServices.Data;
 
 namespace Convenus
@@ -303,6 +301,10 @@ namespace Convenus
         /// <summary>
         /// Last x minutes until room is open
         /// </summary>
-        EndOfMeeting = 3
+        EndOfMeeting = 3,
+        /// <summary>
+        /// Room is a party
+        /// </summary>
+        Party = 4
     }
 }


### PR DESCRIPTION
## Description
If the subject of the "meeting" contains the string `party`, then the spark core will be sent a room status of PARTY.

Also @wliao008, I changed the api endpoint so that it would be a bit more descriptive. `/rooms/{room}/minutes/{minutes}`