### PR TITLE
Mind the Gap - OSS Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Convenus
 ========
+[![](https://img.shields.io/badge/hudl-OSS-orange.svg)](http://hudl.github.io/)
 
 A basic web application to show meeting room status. Runs self-hosted Nancy server. Windows/Mono compatible.
 


### PR DESCRIPTION
This will add a badge to this project to signify it's an open source software project. Clicking the badge links to the new Hudl OSS page.
# NOT READY FOR MERGE UNTIL PAGE IS DEPLOYED
